### PR TITLE
docs(#79): compileHBS README syntax fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import Component from '@glimmer/component';
 import { compileHBS } from 'ember-repl';
 
 export class Renderer extends Component {
-  myComponent = compileHBS(this.args.input);
+  myComponent = compileHBS(this.args.input).component;
 }
 ```
 ```hbs


### PR DESCRIPTION
As per discussion [here](https://github.com/NullVoxPopuli/ember-repl/issues/79#issuecomment-899103451) the `compileHBS` returns an object, which is not possible to use in template. So I guess what we want is to extract the `.component` part from that object and invoke it.