### PR TITLE
doc: its an object

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,18 +38,18 @@ import { tracked } from '@glimmer/tracking';
 import { compileJS } from 'ember-repl';
 
 export class Renderer extends Component {
-  @tracked myComponent;
+  @tracked compileResult;
 
   constructor(...args) {
     super(...args);
 
-    compileJS('...').then(({ component }) => this.myComponent = component);
+    compileJS('...').then((compileResult) => this.compileResult = compileResult);
   }
 }
 ```
 ```hbs
-{{#if this.myComponent}}
-  <this.myComponent />
+{{#if this.compileResult.component}}
+  <this.compileResult.component />
 {{/if}}
 ```
 
@@ -60,11 +60,11 @@ import Component from '@glimmer/component';
 import { compileHBS } from 'ember-repl';
 
 export class Renderer extends Component {
-  myComponent = compileHBS(this.args.input).component;
+  compileResult = compileHBS(this.args.input);
 }
 ```
 ```hbs
-<this.myComponent />
+<this.compileResult.component />
 ```
 
 ### Modifiers and Helpers
@@ -143,15 +143,28 @@ still apply)
 
 ### API
 
-- `compileJS`: async `{ component, error, name }` - compiles a single JS file
+#### Methods
+
+- `compileJS`: async, returns `compileResult` - compiles a single JS file
    uses the syntax from [ember-template-imports](https://github.com/ember-template-imports/ember-template-imports)
-- `compileHBS`: `{ component, error, name }` - compiles a template-only component with no dependencies
+- `compileHBS`: returns `compileResult` - compiles a template-only component with no dependencies
 - `invocationOf`: `string` - converts hyphenated text to an `<AngleBracketInvocation />`
 - `nameFor`: `string` - generates a component-safe GUID-like derivation from code
 
-_`component`_: invokable from templates
-_`error`_: if there is a compilation error, this will be non-falsey
-_`name`_: the name assigned to the input text via UUIDv5
+#### Properties
+
+```ts
+interface CompileResult {
+  // invokable from templates
+  component?: unknown;
+
+  // if there is a compilation error, this will be non-falsey
+  error?: Error;
+
+  // the name assigned to the input text via UUIDv5
+  name: string;
+}
+```
 
 ### Using in an app that uses Embroider
 


### PR DESCRIPTION
Follow-up on #80 

- Examples do not extract `component`, but preserve whole `repl Object`
- Coin new `repl Object` that represent whatever `compile*` returns
- Add cross reference from `repl Object` to it's individual components
- Create sub-sections for the API section to divide methods & properties

Tried to figure out why I bumped "hard" on the README and how to not make it a massive overkill. I think the missing piece might be to "name" what `compileHBS` / `compileJS` is returning, which might:

1) In current format clearly hint that there is more than just `component`
2) Cross reference back in the API section and make it clear what is returned

I'm absolutely not married to this wording, but I think the idea itself might be valuable.

Thoughts? 