### PR TITLE
chore: drop support for node 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,8 +21,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - "12"
           - "14"
+          - "16"
     steps:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
@@ -42,8 +42,8 @@ jobs:
     strategy:
       matrix:
         node:
-          - "12"
           - "14"
+          - "16"
 
     steps:
       - uses: actions/checkout@v2
@@ -68,6 +68,7 @@ jobs:
       matrix:
         ember-try-scenario:
           - ember-3.27
+          - ember-3.28
           - ember-release
           - ember-beta
           - ember-canary
@@ -77,7 +78,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: volta-cli/action@v1
         with:
-          node-version: 12.x
+          node-version: 14.x
       - name: install dependencies
         run: yarn install --frozen-lockfile
       - name: test

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -16,6 +16,14 @@ module.exports = async function () {
         },
       },
       {
+        name: 'ember-3.28',
+        npm: {
+          devDependencies: {
+            'ember-source': '~3.28.0',
+          },
+        },
+      },
+      {
         name: 'ember-release',
         npm: {
           devDependencies: {

--- a/package.json
+++ b/package.json
@@ -140,7 +140,7 @@
     "yarn": "1.22.17"
   },
   "engines": {
-    "node": "10.* || >= 12.22.1"
+    "node": "12.* || >= 14.*"
   },
   "ember": {
     "edition": "octane"


### PR DESCRIPTION
BREAKING CHANGE: drop support for node 12, add 16