### PR TITLE
fix: allow to pass call through the included chain

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,11 @@ module.exports = {
     },
   },
 
-  included(app) {
+  included() {
+    this._super.included.apply(this, arguments);
+
+    const app = this._findHost(this);
+
     // Adds:
     //  - ember-template-compiler
     //  - @glimmer/syntax


### PR DESCRIPTION
Fixes errors like:

```
Could not find module `ember-compatibility-helpers` imported from `@glimmer/component/index`
```